### PR TITLE
修复了不能同时在局部事件和全局事件中使用两次以上返回数据body的BUG，同时将自定义的超时信息伪装成一个response数据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 *.sublime-project
 *.sublime-workspace
 npm-debug.log
+.idea
+*.iml

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,8 @@
 
 'use strict';
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
 var assign = require('beyond-lib/lib/assign');
 var fetch = typeof window !== 'undefined' && window.fetch && !window.__disableNativeFetch ? window.fetch : require('fetch-ie8');
 
@@ -101,10 +103,27 @@ function serialize(obj) {
 	return null;
 }
 
+function fakeResponse(msg, init) {
+	var blobMsg = msg;
+	var type = 'application/json';
+	if ((typeof msg === 'undefined' ? 'undefined' : _typeof(msg)) === 'object') {
+		blobMsg = [JSON.stringify(msg)];
+	}
+	if (typeof msg === 'string') {
+		blobMsg = [msg];
+		type = 'text/html';
+	}
+	if (!isObj(init)) {
+		init = { "status": 500 };
+	}
+	var body = new Blob(blobMsg, { type: type });
+	return new Response(body, init);
+}
 function Timeout(ms, msg) {
 	return new Promise(function (resolve, reject) {
 		setTimeout(function () {
-			reject(msg);
+			var response = fakeResponse(msg, { "status": 408, "statusText": "timeout" });
+			reject(response);
 		}, ms);
 	});
 }
@@ -114,18 +133,22 @@ function createFetch(url, options, timeout, remote) {
 		remote.trigger('start');
 		var result = new Promise(function (resolve, reject) {
 			Promise.race([fetch(url, options), Timeout(timeout.ms, timeout.msg)]).then(function (response) {
+				var resCopy1 = response.clone();
+				var resCopy2 = response.clone();
 				var isSuccess = response.ok || response.status >= 200 && response.status < 300;
 				if (isSuccess) {
-					remote.trigger('success', response);
+					remote.trigger('success', resCopy1);
 				} else {
 					throw response;
 				}
-				remote.trigger('complete', response);
+				remote.trigger('complete', resCopy2);
 				var data = response.headers.get('content-type') && response.headers.get('content-type').indexOf('json') >= 0 ? response.json() : response.text();
 				resolve(data);
 			})['catch'](function (error) {
-				remote.trigger('error', error);
-				remote.trigger('complete', error);
+				var errorCopy1 = error.clone();
+				var errorCopy2 = error.clone();
+				remote.trigger('error', errorCopy1);
+				remote.trigger('complete', errorCopy2);
 				reject(error);
 			});
 			remote.trigger('send');
@@ -143,11 +166,8 @@ function Remote() {
 		method: 'GET',
 		requestJSON: true,
 		responseJSON: true,
-		timeout: 90000,
+		timeout: 10,
 		timeoutMsg: {
-			ok: false,
-			text: 'timeout',
-			status: 900,
 			title: '服务器超时！请重试！'
 		},
 		credentials: 'omit'

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.0",
     "es5-shim": "^4.5.7",
+    "es6-promise": "^3.1.2",
     "eslint": "^1.10.2",
     "exports-loader": "^0.6.2",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.8.5",
     "html-webpack-plugin": "^1.6.2",
     "imports-loader": "^0.6.5",
+    "jasmine-core": "^2.4.1",
     "json-server": "^0.8.4",
     "karma": "^0.13.15",
     "karma-babel-preprocessor": "^6.0.1",
@@ -48,8 +50,7 @@
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.6",
-    "webpack-dev-server": "^1.12.1",
-    "es6-promise": "^3.1.2"
+    "webpack-dev-server": "^1.12.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
然后因为response的body只能使用一次，所以同时在全局和局部事件里面同时处理response的body会挂掉，在本毛新push的版本里面对response做了拷贝，解决了这个问题

另外如果定义timeoutMsg是一个string, 那么fake Response的body的mime类型会被定义成text/html
如果是其他格式会被定义成application/json格式
默认定义为{title: "服务器超时“}
这样返回的错误无论是自定义还是真实的，都可以用response.json()或response.text()处理了哟

如果有不明白的请看代码。或者直接问我本人→_→ 
然后我觉得你的readme好重新写写嘞=w=