### PR TITLE
修复url中带有协议时，发起请求的url错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-preset-es2015": "^6.3.13",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.0",
+    "es5-shim": "^4.5.9",
     "es6-promise": "^3.1.2",
     "eslint": "^1.10.2",
     "exports-loader": "^0.6.2",

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ function mergeUrl(basePath = '', path = '') {
 	if (!basePath && !path ) {
 		return ''
 	}else{
-		return basePath ? (basePath + '/' + path).replace(/([^:])\/+/g, '$1/') : path
+		return basePath ? (basePath + '/' + path).replace(/([^:\/])\/+/g, '$1/') : path
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ function mergeUrl(basePath = '', path = '') {
 	if (!basePath && !path ) {
 		return ''
 	}else{
-		return (basePath + '/' + path).replace(/\/+/g, '/')
+		return basePath ? (basePath + '/' + path).replace(/([^:])\/+/g, '$1/') : path
 	}
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,27 @@ describe("remote", function () {
         url: 'https://api.github.com/events',
         timeout: 0
     })
+    it("should fetch with correct url", function (done){
+        var remote = new beyondRemote.Remote
+        var pathname = '/mock/db.html'
+        var basePath = location.protocol + '//' + location.host
+        remote.base({
+            basePath: basePath + '/'
+        })
+        var call = remote.create({
+            url: pathname
+        })
+        function handlerComplete(response){
+           if(!response.url){
+               console.warn('can not find response.url')
+               done()
+               return
+           }
+            expect(response.url).toEqual(basePath + pathname)
+            done();
+        }
+        call().then(handlerComplete, handlerComplete)
+    })
     it("should works well on json fetch", function (done) {
         expect(typeof jsonCall === 'function').toEqual(true)
         jsonCall().then(function (data) {


### PR DESCRIPTION
`
remote.base({
  basePath: basePath 
})

remote.create({
 url: url
})

basePath = 'http://api.github.com'
url = 'events'
->expect url === 'http://api.github.com', in fact url === 'http:/api.github.com/events'

basePath = '//api.github.com'
url = 'events'
->expect url === '//api.github.com', in fact url === '/api.github.com/events'
`
changes:
1.修复这个问题并增加测试
2.增加es5-shim到devDependencies

另外timeout的测试 在IE8和9中一直是失败，chrome有几率失败。